### PR TITLE
[codex] Add direct OP CLI runner skill

### DIFF
--- a/docs/adr/0044-use-op-cli-runner-for-1password-cli-auth.md
+++ b/docs/adr/0044-use-op-cli-runner-for-1password-cli-auth.md
@@ -1,0 +1,42 @@
+---
+title: "Use Direct OP CLI Runner For 1Password CLI Auth"
+date: 2026-06-16
+agent_model: "GPT-5 Codex"
+status: accepted
+---
+
+# ADR 0044: Use Direct OP CLI Runner For 1Password CLI Auth
+
+## Context
+
+Codex subprocesses can fail to complete 1Password CLI app-integration prompts even when the user repeatedly approves Touch ID. Observed failure modes include `account is not signed in`, `promptError`, `authorization prompt dismissed`, `authorization timeout`, and silent waits while `opmaterialize` downloads manifest-backed documents.
+
+Adding Terminal, AppleScript, GUI, or alternate-shell fallbacks makes the root cause harder to see because each path has different authentication and session behavior.
+
+Local verification also separated wrapper availability from authentication:
+
+- `opmaterialize add` is a one-file operation; multiple positional file paths are invalid before any 1Password call.
+- Missing deployed `opmaterialize` wrapper exits 127 and should route to the bundled installed-skill script path.
+- Missing wrapper is not an authentication failure and should not trigger auth troubleshooting.
+
+The file-backed secret workflow still belongs to `onepassword-secret-materialize`, but raw execution of `op` from Codex's pseudo-TTY is not reliable enough as the default recovery path.
+
+## Decision
+
+Add a separate `op-cli-runner` skill for 1Password CLI execution mechanics.
+
+Use it when running `op`, `opmaterialize`, or restore flows that may require app-integration authentication. The runner records redacted command metadata, bounded logs, summary JSON, and failure classification.
+
+Keep the runner to one direct subprocess execution path. If the direct path reports authentication, prompt, authorization, or timeout failures, stop and report that classified failure instead of switching to a fallback.
+
+Keep secret workflow policy and manifest semantics in `onepassword-secret-materialize`. Use `op-cli-runner` only as the execution layer.
+
+Use `opmaterialize add` one file at a time. If the deployed wrapper is absent, invoke the installed skill's bundled script with explicit account and vault environment variables; keep that as a wrapper-availability recovery, not an auth workaround.
+
+## Consequences
+
+- Agents should stop repeatedly retrying raw `op` commands from Codex when app-integration prompts fail.
+- 1Password-backed restores become observable through `.context/` artifacts.
+- Failure causes remain easier to diagnose because there is only one execution path.
+- Wrapper-not-found and unauthenticated-session failures remain separate operational categories.
+- Commands that print secret values remain unsafe unless the caller explicitly provides a secret-safe output path and reporting plan.

--- a/docs/skills-install-manifest.md
+++ b/docs/skills-install-manifest.md
@@ -1,6 +1,6 @@
 ---
 title: "Skill Install Manifest"
-updated_at: 2026-06-09
+updated_at: 2026-06-16
 ---
 
 # Skill Install Manifest
@@ -31,6 +31,7 @@ gh skill install . copilot-cli-runner --from-local --agent claude-code --scope u
 gh skill install . agent-orchestration-evaluator --from-local --agent claude-code --scope user
 gh skill install . soundcore-minutes --from-local --agent claude-code --scope user
 gh skill install . ghq-repo-placement --from-local --agent claude-code --scope user
+gh skill install . op-cli-runner --from-local --agent claude-code --scope user
 gh skill install . onepassword-secret-materialize --from-local --agent claude-code --scope user
 gh skill install . handoff --from-local --agent claude-code --scope user
 gh skill install . git-branch-review --from-local --agent claude-code --scope user
@@ -52,6 +53,7 @@ gh skill install . gemini-cli-runner --from-local --agent codex --scope user
 gh skill install . copilot-cli-runner --from-local --agent codex --scope user
 gh skill install . soundcore-minutes --from-local --agent codex --scope user
 gh skill install . ghq-repo-placement --from-local --agent codex --scope user
+gh skill install . op-cli-runner --from-local --agent codex --scope user
 gh skill install . onepassword-secret-materialize --from-local --agent codex --scope user
 gh skill install . handoff --from-local --agent codex --scope user
 gh skill install . git-branch-review --from-local --agent codex --scope user

--- a/skills/onepassword-secret-materialize/SKILL.md
+++ b/skills/onepassword-secret-materialize/SKILL.md
@@ -38,6 +38,8 @@ Use this when the user says a file is ready and should be saved for other PCs.
    opmaterialize add <path>
    ```
 
+   `opmaterialize add` takes exactly one file path. Run one add command per file; passing multiple positional file paths is invalid and exits before contacting 1Password.
+
    If the deployed command is not available in the current shell, run the bundled script:
 
    ```bash
@@ -90,10 +92,13 @@ Use this when setting up a new machine or rehydrating ignored local config files
    opmaterialize restore --force
    ```
 
+If Codex's normal shell cannot complete 1Password app-integration prompts, or `op` reports `account is not signed in`, `promptError`, `authorization prompt dismissed`, or waits silently, use `$op-cli-runner` to execute `opmaterialize diff` or `opmaterialize restore` through one observable direct path. Do not add Terminal, GUI, or alternate shell fallbacks; report the classified failure and fix the underlying 1Password CLI/session issue.
+
 ## Troubleshooting
 
 - If `op` reports multiple accounts, use `OP_ACCOUNT=my.1password.com`.
 - If `op` requires authentication, let the user unlock/sign in to 1Password; do not ask them to paste secrets into chat.
+- If `opmaterialize` is missing or exits 127, use the bundled script path from the installed skill; do not classify missing wrapper as an auth failure.
 - If `Dotfiles Secrets` or `Secrets Manifest` is missing, create or ask the user to create it in 1Password rather than storing its content in git.
 - If a requested generated path is not ignored, update `.chezmoiignore` before registering the file.
 - If changing the managed script, README, ADR, `.chezmoiignore`, or deployed dotfiles, follow the repository `dotfile-update` workflow.
@@ -107,7 +112,7 @@ After editing the workflow implementation or docs, run:
 shellcheck skills/onepassword-secret-materialize/scripts/opmaterialize dot_local/bin/executable_opmaterialize dot_local/bin/executable_oprun
 git diff --check -- . ':(exclude).context'
 scripts/chezmoi-drift --check-ignore
-scripts/skill-quick-validate .claude/skills/onepassword-secret-materialize
+scripts/skill-quick-validate skills/onepassword-secret-materialize
 ```
 
 For behavior changes, use a fake `op` in `.context/` to test `diff`, `restore`, and `add` without touching live 1Password.

--- a/skills/op-cli-runner/SKILL.md
+++ b/skills/op-cli-runner/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: op-cli-runner
+description: Run 1Password CLI (`op`) and `opmaterialize` commands through one direct, observable subprocess path with bounded timeouts, redacted command metadata, and failure classification. Use when Codex needs to execute `op`, `opmaterialize`, `op signin`, restore 1Password-backed files, debug `account is not signed in`, `promptError`, `authorization prompt dismissed`, `authorization timeout`, or avoid silent hangs around 1Password CLI authentication without introducing alternate fallback execution paths.
+---
+
+# OP CLI Runner
+
+Use this skill for the execution mechanics of 1Password CLI commands. Keep higher-level secret workflows in their owning skill, for example `$onepassword-secret-materialize` for `Secrets Manifest` and file restore policy.
+
+## Core Rule
+
+Run `op` through one direct wrapper path and let failures remain visible. Do not add Terminal, AppleScript, GUI, or shell-session fallback paths inside this skill; they obscure the real failure mode.
+
+If `op whoami`, `op vault list`, or `opmaterialize diff` fails with `account is not signed in`, `promptError`, `authorization prompt dismissed`, `authorization timeout`, or a timeout, stop and report the classified failure from `summary.json`.
+
+## Safety
+
+- Do not print secret values.
+- Do not run `op read`, `op item get --reveal`, or commands expected to write secret values to stdout unless the caller explicitly provides a secret-safe output path and reporting plan.
+- Prefer commands that write secrets directly to files, such as `op document get --out-file ...`, or workflows like `opmaterialize` that avoid printing secret contents.
+- Treat `op://...` references as sensitive operational material. The wrapper redacts them from metadata, but avoid passing them through command lines when a file or env-file handoff is available.
+- Save logs under `.context/<task>/`, not `/tmp`.
+
+## Wrapper
+
+Use the bundled wrapper instead of raw `op` for non-trivial work:
+
+```bash
+python3 skills/op-cli-runner/scripts/run_op_cli.py \
+  --output-dir .context/<task>/op \
+  --cwd /path/to/repo \
+  -- opmaterialize diff
+```
+
+The wrapper writes:
+
+- `command.redacted.json`: command arguments with `op://...` references redacted
+- `run.log`: timestamped runner log and subprocess output
+- `summary.json`: mode, cwd, command metadata, exit code, elapsed time, and failure classification
+
+## Direct Execution
+
+Use the wrapper for direct execution:
+
+```bash
+python3 skills/op-cli-runner/scripts/run_op_cli.py \
+  --output-dir .context/<task>/op-whoami \
+  -- op whoami --account my.1password.com
+```
+
+If the wrapper returns `auth_required`, `prompt_error`, `authorization_dismissed`, `auth_timeout`, or `timeout`, do not retry the same command repeatedly. Preserve the artifacts and fix the underlying 1Password CLI/session/app-integration issue outside this skill.
+
+When the command is `op signin`, the wrapper verifies success with `op whoami --account <account>`. Treat `op signin` exit 0 as insufficient unless `whoami` confirms the session.
+
+## Restore Pattern
+
+For 1Password-backed dotfiles:
+
+1. Use `$onepassword-secret-materialize` for restore policy.
+2. Use this skill's wrapper for execution:
+
+   ```bash
+   python3 skills/op-cli-runner/scripts/run_op_cli.py \
+     --output-dir .context/<task>/op-diff \
+     --cwd /Users/rmanzoku/.local/share/chezmoi \
+     --timeout-seconds 900 \
+     -- opmaterialize diff
+   ```
+
+3. If `diff` exits `1`, that means missing or changed files exist. Run restore:
+
+   ```bash
+   python3 skills/op-cli-runner/scripts/run_op_cli.py \
+     --output-dir .context/<task>/op-restore \
+     --cwd /Users/rmanzoku/.local/share/chezmoi \
+     --timeout-seconds 900 \
+     -- opmaterialize restore
+   ```
+
+4. If restore reports target conflicts, do not force overwrite silently. Ask for explicit confirmation before `opmaterialize restore --force`.
+5. After restore, run `chezmoi apply` and drift checks through the owning dotfile workflow.
+
+## Wrapper Availability
+
+Treat a missing `opmaterialize` wrapper separately from 1Password authentication failures. If `opmaterialize` is not found or exits 127 before contacting 1Password, use the bundled script path from the installed skill:
+
+```bash
+OP_ACCOUNT=my.1password.com \
+OP_DOTFILES_MATERIALIZE_VAULT="Dotfiles Secrets" \
+sh ~/.codex/skills/onepassword-secret-materialize/scripts/opmaterialize diff
+```
+
+Use this only for wrapper availability. Do not use it as an authentication fallback.
+
+## Failure Handling
+
+Classify failures from `summary.json.failure_kind`:
+
+- `auth_required`: CLI is not signed in for the selected account.
+- `prompt_error`: 1Password app integration prompt could not be displayed or completed from the current process.
+- `authorization_dismissed`: the auth prompt was dismissed or not completed.
+- `auth_timeout`: the auth prompt did not complete before 1Password CLI timed out.
+- `signin_unverified`: `op signin` exited without error, but `op whoami` did not confirm a usable session.
+- `timeout`: command exceeded the wrapper timeout.
+- `command_failed`: command exited non-zero without a known auth signature.
+- exit 127 from `opmaterialize`: wrapper missing or not on `PATH`; check wrapper availability before auth troubleshooting.
+
+For recurring `prompt_error`, `auth_timeout`, or silent waits, do not add another fallback inside this skill. Report the failure and update the environment, 1Password app integration, or caller workflow so the direct command can succeed or fail deterministically.
+
+## Validation
+
+After changing this skill, run:
+
+```bash
+python3 skills/op-cli-runner/scripts/run_op_cli.py --help
+python3 -m py_compile skills/op-cli-runner/scripts/run_op_cli.py
+scripts/skill-quick-validate skills/op-cli-runner
+```

--- a/skills/op-cli-runner/agents/openai.yaml
+++ b/skills/op-cli-runner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OP CLI Runner"
+  short_description: "Run 1Password CLI directly with clear failures"
+  default_prompt: "Use $op-cli-runner to run an op or opmaterialize command with safe logging."

--- a/skills/op-cli-runner/scripts/run_op_cli.py
+++ b/skills/op-cli-runner/scripts/run_op_cli.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Run op/opmaterialize commands with observable direct logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+AUTH_SIGNATURES = [
+    ("auth_required", re.compile(r"account is not signed in", re.I)),
+    ("prompt_error", re.compile(r"promptError|prompt error", re.I)),
+    ("authorization_dismissed", re.compile(r"authorization prompt dismissed", re.I)),
+    ("auth_timeout", re.compile(r"authorization timeout", re.I)),
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def redact_arg(arg: str) -> str:
+    return re.sub(r"op://[^\s'\"`]+", "op://REDACTED", arg)
+
+
+def classify(text: str, exit_code: int | None, timed_out: bool) -> str | None:
+    if timed_out:
+        return "timeout"
+    for name, pattern in AUTH_SIGNATURES:
+        if pattern.search(text):
+            return name
+    if exit_code not in (None, 0):
+        return "command_failed"
+    return None
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def log_line(log_path: Path, message: str) -> None:
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{utc_now()} {message}\n")
+
+
+def signin_account(command: list[str]) -> str | None:
+    if len(command) < 2 or Path(command[0]).name != "op" or command[1] != "signin":
+        return None
+    for index, value in enumerate(command):
+        if value == "--account" and index + 1 < len(command):
+            return command[index + 1]
+        if value.startswith("--account="):
+            return value.split("=", 1)[1]
+    return os.environ.get("OP_ACCOUNT")
+
+
+def verify_signin(args: argparse.Namespace, command: list[str], log_path: Path) -> tuple[bool, str | None, str]:
+    account = signin_account(command)
+    if not account:
+        return True, None, ""
+
+    verify_command = ["op", "whoami", "--account", account]
+    log_line(log_path, f"[verify] op whoami --account {account}")
+    try:
+        proc = subprocess.run(
+            verify_command,
+            cwd=args.cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=min(args.timeout_seconds, 60),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        combined = f"{exc.stdout or ''}\n{exc.stderr or ''}"
+        log_line(log_path, "[verify-timeout] signin verification exceeded timeout")
+        return False, "signin_unverified", combined
+
+    if proc.returncode == 0:
+        log_line(log_path, "[verify] signin verified by whoami")
+        return True, None, f"{proc.stdout}\n{proc.stderr}"
+
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    if proc.stderr:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(proc.stderr)
+            if not proc.stderr.endswith("\n"):
+                fh.write("\n")
+    failure = classify(combined, proc.returncode, False) or "signin_unverified"
+    log_line(log_path, f"[verify-failed] signin did not create a usable session failure_kind={failure}")
+    return False, failure, combined
+
+
+def run_direct(args: argparse.Namespace, command: list[str], out_dir: Path, log_path: Path) -> dict:
+    started = time.monotonic()
+    log_line(log_path, f"[start] direct cwd={args.cwd}")
+    timed_out = False
+    exit_code: int | None = None
+    combined = ""
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=args.cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=args.timeout_seconds,
+            check=False,
+        )
+        exit_code = proc.returncode
+        if proc.stdout:
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write(proc.stdout)
+                if not proc.stdout.endswith("\n"):
+                    fh.write("\n")
+        if proc.stderr:
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write(proc.stderr)
+                if not proc.stderr.endswith("\n"):
+                    fh.write("\n")
+        combined = f"{proc.stdout}\n{proc.stderr}"
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        exit_code = 124
+        combined = f"{exc.stdout or ''}\n{exc.stderr or ''}"
+        log_line(log_path, f"[timeout] exceeded {args.timeout_seconds}s")
+
+    verify_failure: str | None = None
+    if exit_code == 0 and not timed_out:
+        verified, verify_failure, verify_output = verify_signin(args, command, log_path)
+        combined = f"{combined}\n{verify_output}"
+        if not verified:
+            exit_code = 1
+
+    elapsed = round(time.monotonic() - started, 3)
+    failure_kind = verify_failure or classify(combined, exit_code, timed_out)
+    log_line(log_path, f"[done] direct exit_code={exit_code} elapsed={elapsed}s failure_kind={failure_kind or 'none'}")
+    return {
+        "mode": "direct",
+        "cwd": str(Path(args.cwd).resolve()),
+        "exit_code": exit_code,
+        "elapsed_seconds": elapsed,
+        "timed_out": timed_out,
+        "failure_kind": failure_kind,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run op/opmaterialize through one observable direct subprocess path.")
+    parser.add_argument("--output-dir", required=True, help="Directory for logs and summary artifacts.")
+    parser.add_argument("--cwd", default=os.getcwd(), help="Working directory for the command.")
+    parser.add_argument("--timeout-seconds", type=int, default=300, help="Timeout for the command.")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to run after --, e.g. -- op whoami.")
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("command is required after --")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = out_dir / "run.log"
+    redacted = [redact_arg(part) for part in args.command]
+    (out_dir / "command.redacted.json").write_text(json.dumps(redacted, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    summary = run_direct(args, args.command, out_dir, log_path)
+
+    summary.update(
+        {
+            "created_at": utc_now(),
+            "command_redacted": redacted,
+            "output_dir": str(out_dir),
+        }
+    )
+    write_json(out_dir / "summary.json", summary)
+    return int(summary.get("exit_code") or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Add `op-cli-runner`, a direct-only wrapper skill for running `op` and `opmaterialize` with redacted command metadata, timeout handling, and failure classification.
- Document 1Password CLI auth and wrapper-availability behavior in ADR 0044.
- Update `onepassword-secret-materialize` guidance for one-file `opmaterialize add`, missing-wrapper handling, and direct runner usage.
- Add `op-cli-runner` to the first-party skill install manifest for Claude Code and Codex.

## Validation

- `python3 -m py_compile skills/op-cli-runner/scripts/run_op_cli.py`
- `scripts/skill-quick-validate skills/op-cli-runner`
- `scripts/skill-quick-validate skills/onepassword-secret-materialize`
- `python3 skills/op-cli-runner/scripts/run_op_cli.py --output-dir .context/op-cli-runner-pr-smoke -- /usr/bin/true`
- Verified `opmaterialize add /tmp/a /tmp/b` exits 64 before contacting 1Password.
- `git diff --check -- . ':(exclude).context'`
- `scripts/chezmoi-drift --check-ignore`

## Notes

This PR was built from `origin/main` in a separate worktree to avoid including the existing local `main` ahead commit and the unrelated `skills/code-evaluator/SKILL.md` working-tree change.