### PR TITLE
grok-cli-runner: fail on non-EndTurn stop reason and fix always-approve flag conflict

### DIFF
--- a/skills/grok-cli-runner/SKILL.md
+++ b/skills/grok-cli-runner/SKILL.md
@@ -17,9 +17,10 @@ Frame each delegation as an outcome-first contract: request artifact, expected r
 - Use `--dry-run` for request-shape and command validation; it does not call Grok Build and intentionally does not create a response artifact.
 - In `--dry-run`, success is checked through `summary.json.dry_run_payload`; do not require `grok-response.json` to exist.
 - Use the wrapper's 600-second process timeout default, or pass `--timeout-seconds` when the task needs a shorter or longer limit.
-- Use `--permission-mode auto --no-plan` by default. Pass `--plan` only when Grok Build plan mode is explicitly desired.
+- Use `--permission-mode auto --no-plan` by default for read-only tasks that return their result in the response body. Pass `--plan` only when Grok Build plan mode is explicitly desired.
+- For tasks that must run shell commands or write files, pass `--permission-mode bypassPermissions`. Headless Grok cannot answer permission prompts: under `auto` the first side-effect tool call is cancelled and the run ends with exit 0 and `stopReason=Cancelled`.
 - The wrapper passes `--verbatim` by default so Grok receives the derived prompt directly. Use `--no-verbatim` only when Grok Build's default prompt shaping is explicitly needed.
-- Pass `--always-approve` only when the caller explicitly accepts tool side effects.
+- Pass `--always-approve` only when the caller explicitly accepts tool side effects. The wrapper then omits `--permission-mode` entirely, because grok 0.2.112 lets an explicit `--permission-mode` override `--always-approve` (contrary to its docs) and cancels headless runs.
 - Pass session flags only when session state is part of the task contract. Default to a stateless one-shot headless run.
 - Do not treat 0-byte `run.err` or a missing response artifact alone as a hang; use exit code, timeout, `summary.json`, and failure reasons.
 - Do not add fallback backends. If Grok Build CLI is missing, unauthenticated, or rejected by model/permission state, report that failure from the artifacts.
@@ -57,7 +58,7 @@ Before running Grok, make these decisions explicitly:
 - Response artifact: pass `--response-artifact grok-response.json` when the response belongs inside `--output-dir`; use an absolute path only when the response must be written outside `--output-dir`.
 - Model: omit `--model` unless the caller or model registry requires an override. The wrapper resolves `--model`, then `request.model`, then `GROK_BUILD_MODEL`, then `GROK_MODEL`; when none is set it omits `-m` and Grok Build CLI uses its own default model.
 - Timeout: rely on the 600-second wrapper default unless the task contract says otherwise.
-- Permission mode: rely on `--permission-mode auto --no-plan` unless the caller explicitly chooses another Grok Build permission mode.
+- Permission mode: rely on `--permission-mode auto --no-plan` for read-only tasks; pass `--permission-mode bypassPermissions` when the task must run shell commands or write files (for example when the expected artifact is written by Grok itself).
 - Verbatim mode: keep the default `--verbatim`; use `--no-verbatim` only for compatibility testing.
 - Output format: rely on `--output-format json`; use `streaming-json` only when incremental event capture matters, and `plain` only for compatibility.
 - Session state: omit `--session-id`, `--resume`, and `--continue-session` unless continuity is required and documented in the request.
@@ -95,10 +96,10 @@ Add these only when needed:
 - `--model <model>` to override model defaulting.
 - `--timeout-seconds <seconds>` to override the 600-second process timeout.
 - `--grok-bin <path>` when the `grok` executable is not on `PATH`.
-- `--permission-mode <mode>` when the caller explicitly chooses a Grok Build permission mode.
+- `--permission-mode <mode>` when the caller explicitly chooses a Grok Build permission mode; use `bypassPermissions` for tasks with shell or file side effects.
 - `--plan` only when Grok Build plan mode is explicitly desired.
 - `--no-verbatim` only when the caller explicitly wants Grok Build's default prompt shaping.
-- `--always-approve` only when tool side effects are explicitly accepted.
+- `--always-approve` only when tool side effects are explicitly accepted; the wrapper then omits `--permission-mode`.
 - `--session-id <id>`, `--resume <id>`, or `--continue-session` only when session continuity is part of the task.
 - `--output-format streaming-json` only when event capture matters.
 
@@ -118,7 +119,7 @@ The wrapper writes:
 - stdout progress lines: Grok Build start, completion, and failure status.
 - resolved response artifact, normally `grok-response.json`: normalized response artifact for successful real calls.
 - `run.err`: Grok Build stderr and local wrapper diagnostics.
-- `summary.json`: redacted command, resolved `cwd`, exit code, elapsed time, byte counts, model, output format, permission mode, session flags, dry-run payload, response artifact path/status, `failure_reasons`, and `recommended_next_action`.
+- `summary.json`: redacted command, resolved `cwd`, exit code, `stop_reason`, elapsed time, byte counts, model, output format, effective permission mode (`null` when `--always-approve` suppressed it), session flags, dry-run payload, response artifact path/status, `failure_reasons`, and `recommended_next_action`.
 - `summary.json.no_plan` and `summary.json.verbatim`: whether `--no-plan` and `--verbatim` were used.
 - `failure.md`: only when the wrapper run fails.
 
@@ -144,6 +145,7 @@ Important request rules:
 Require all applicable checks:
 
 - Process exit code is `0`.
+- For real runs with `json` or `streaming-json` output, `summary.json.stop_reason` is `EndTurn`.
 - For real runs, the resolved response artifact exists and is non-empty.
 - Response artifact contains `request`, `response`, `model` (`null` when the run delegated to the Grok Build CLI default model), `backend`, and `output_text` or parsed stdout sufficient for the caller to inspect.
 - `summary.json.success` is `true`, `summary.json.failure_reasons` is empty, and `summary.json.response_non_empty` is `true`.
@@ -161,6 +163,7 @@ Treat any of these as failure:
 - Missing `request.input`.
 - Missing `grok` executable.
 - Grok Build auth, model, permission, policy, update, or rate-limit errors.
+- `stop_reason` other than `EndTurn`, normally `Cancelled` from a headless permission prompt that nothing could answer (exit code stays `0`; only `stop_reason` reveals the failure).
 - Real run response artifact is missing or empty.
 
 On failure, inspect `.context/<task>/summary.json` first:
@@ -168,6 +171,7 @@ On failure, inspect `.context/<task>/summary.json` first:
 - `command`
 - `cwd`
 - `exit_code`
+- `stop_reason`
 - `elapsed_seconds`
 - `request_bytes`, `prompt_bytes`, `response_bytes`, and `stderr_bytes`
 - `model`
@@ -203,6 +207,7 @@ Do not hand-edit `summary.json`, `run.err`, the response artifact, or `failure.m
 - Pass `--cwd <project-root>` when the caller wants Grok Build launched from a specific repository.
 - `summary.json.command` redacts the prompt body as `<prompt from request artifact>`; the request artifact remains the source of truth.
 - The wrapper passes `--no-auto-update` on every real run to avoid background update checks in automation.
+- Known issue (grok 0.2.112): an explicit `--permission-mode` overrides `--always-approve`, contrary to the Grok docs statement that always-approve wins. The wrapper therefore never sends both flags together.
 - Keep final orchestration in the caller. This skill only calls Grok Build and records observable artifacts.
 
 ## Validation

--- a/skills/grok-cli-runner/references/schema.md
+++ b/skills/grok-cli-runner/references/schema.md
@@ -114,7 +114,7 @@ Important fields:
 - `backend`: `grok-build`
 - `grok_bin`
 - `output_format`
-- `permission_mode`
+- `permission_mode`: effective mode passed to Grok Build; `null` when `--always-approve` suppressed the flag
 - `no_plan`
 - `verbatim`
 - `session_id`, `resume`, `continue_session`, `always_approve`
@@ -122,6 +122,7 @@ Important fields:
 - `dry_run_payload`: present only for dry-run success and includes the normalized request, prompt byte count, and redacted command
 - `prompt_bytes`
 - `exit_code`
+- `stop_reason`: Grok Build stop reason parsed from `json` / `streaming-json` stdout (`EndTurn` on completion; `Cancelled` normally means an unanswerable headless permission prompt); `null` for `plain` output and dry-run
 - `elapsed_seconds`
 - `request_bytes`, `response_bytes`, `stderr_bytes`
 - `response_non_empty`

--- a/skills/grok-cli-runner/scripts/run_grok_cli.py
+++ b/skills/grok-cli-runner/scripts/run_grok_cli.py
@@ -81,7 +81,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--always-approve",
         action="store_true",
-        help="Pass --always-approve to Grok Build. Use only when the caller explicitly accepts tool side effects.",
+        help=(
+            "Pass --always-approve to Grok Build and omit --permission-mode "
+            "(grok 0.2.112 lets an explicit --permission-mode override --always-approve). "
+            "Use only when the caller explicitly accepts tool side effects."
+        ),
     )
     return parser.parse_args()
 
@@ -228,7 +232,9 @@ def build_grok_command(args: argparse.Namespace, timeout_bin: str, payload: dict
     model = payload.get("model")
     if model:
         command.extend(["-m", str(model)])
-    if args.permission_mode:
+    # grok 0.2.112: an explicit --permission-mode overrides --always-approve
+    # (contrary to its docs), so the two flags must never be sent together.
+    if args.permission_mode and not args.always_approve:
         command.extend(["--permission-mode", args.permission_mode])
     if args.no_plan:
         command.append("--no-plan")
@@ -293,6 +299,22 @@ def extract_text_from_value(value: Any) -> str | None:
     return None
 
 
+def extract_stop_reason(parsed_stdout: Any) -> str | None:
+    if not isinstance(parsed_stdout, dict):
+        return None
+    value = parsed_stdout.get("stopReason")
+    if isinstance(value, str) and value:
+        return value
+    events = parsed_stdout.get("events")
+    if isinstance(events, list):
+        for event in reversed(events):
+            if isinstance(event, dict):
+                value = event.get("stopReason")
+                if isinstance(value, str) and value:
+                    return value
+    return None
+
+
 def run_grok_build(
     args: argparse.Namespace,
     command: list[str],
@@ -300,7 +322,7 @@ def run_grok_build(
     payload: dict[str, Any],
     response_path: Path,
     stderr_path: Path,
-) -> int:
+) -> tuple[int, str | None]:
     if not shutil.which(args.grok_bin):
         raise RuntimeError(
             f"Grok Build executable not found: {args.grok_bin}. Install with `curl -fsSL https://x.ai/cli/install.sh | bash` "
@@ -318,9 +340,10 @@ def run_grok_build(
         )
     if proc.returncode != 0:
         log_progress(f"Grok Build headless run failed exit_code={proc.returncode}")
-        return proc.returncode
+        return proc.returncode, None
     stdout_text = proc.stdout.decode("utf-8", errors="replace")
     parsed_stdout, output_text = parse_stdout(stdout_text, args.output_format)
+    stop_reason = extract_stop_reason(parsed_stdout)
     artifact = {
         "task": require_string(request_artifact, "task"),
         "created_at": datetime.now(timezone.utc).isoformat(),
@@ -338,8 +361,11 @@ def run_grok_build(
         "backend": "grok-build",
     }
     write_json(response_path, artifact)
-    log_progress(f"completed Grok Build headless run bytes={len(proc.stdout)}")
-    return 0
+    if stop_reason is not None and stop_reason != "EndTurn":
+        log_progress(f"Grok Build turn did not complete stop_reason={stop_reason}")
+    else:
+        log_progress(f"completed Grok Build headless run bytes={len(proc.stdout)}")
+    return 0, stop_reason
 
 
 def classify_failure_reasons(
@@ -348,6 +374,7 @@ def classify_failure_reasons(
     api_error: dict[str, Any] | None,
     response_non_empty: bool,
     dry_run: bool,
+    stop_reason: str | None,
 ) -> list[str]:
     reasons: list[str] = []
     if exit_code == 124:
@@ -362,6 +389,8 @@ def classify_failure_reasons(
             reasons.append("invalid_request")
         else:
             reasons.append("grok_build_error")
+    if not dry_run and exit_code == 0 and stop_reason is not None and stop_reason != "EndTurn":
+        reasons.append("stop_reason_not_end_turn")
     if not dry_run and not response_non_empty and "missing_grok" not in reasons and "invalid_request" not in reasons:
         reasons.append("missing_response_artifact")
     return reasons
@@ -376,6 +405,12 @@ def recommended_next_action(failure_reasons: list[str], *, dry_run: bool) -> str
         return "Inspect request size and Grok Build state, then rerun with a smaller request or larger --timeout-seconds."
     if "invalid_request" in failure_reasons:
         return "Fix grok-request.json against references/schema.md, then rerun with --dry-run before a real call."
+    if "stop_reason_not_end_turn" in failure_reasons:
+        return (
+            "Grok Build ended the turn without completing (stop_reason != EndTurn; Cancelled usually means a headless "
+            "permission prompt nobody could answer). For tasks with shell or file side effects rerun with "
+            "--permission-mode bypassPermissions, and inspect events.jsonl under ~/.grok/sessions/ for permission_cancelled."
+        )
     if "missing_response_artifact" in failure_reasons:
         return "Inspect run.err and Grok Build stdout behavior, then rerun after fixing auth, model, permission mode, or request shape."
     return "Inspect summary.json and grok-response.json, then integrate the response in the caller."
@@ -389,6 +424,7 @@ def write_failure(path: Path, summary: dict[str, Any]) -> None:
         "",
         f"- Command: `{' '.join(summary['command'])}`",
         f"- Exit code: `{summary['exit_code']}`",
+        f"- Stop reason: `{summary.get('stop_reason')}`",
         f"- Elapsed seconds: `{summary['elapsed_seconds']}`",
         f"- Request bytes: `{summary['request_bytes']}`",
         f"- Response artifact: `{summary['response_artifact']}`",
@@ -426,6 +462,7 @@ def main() -> int:
     api_error: dict[str, Any] | None = None
     dry_run_payload: dict[str, Any] | None = None
     exit_code = 0
+    stop_reason: str | None = None
     model_used = args.model or os.getenv("GROK_BUILD_MODEL") or os.getenv("GROK_MODEL") or None
     command: list[str] = []
     prompt_bytes = 0
@@ -446,7 +483,7 @@ def main() -> int:
             }
             stderr_path.write_text("", encoding="utf-8")
         else:
-            exit_code = run_grok_build(args, command, request_data, payload, response_path, stderr_path)
+            exit_code, stop_reason = run_grok_build(args, command, request_data, payload, response_path, stderr_path)
     except Exception as exc:  # noqa: BLE001 - convert all local/backend failures to artifacts
         exit_code = 1
         api_error = {"type": exc.__class__.__name__, "message": str(exc)}
@@ -461,6 +498,7 @@ def main() -> int:
         api_error=api_error,
         response_non_empty=response_non_empty,
         dry_run=args.dry_run,
+        stop_reason=stop_reason,
     )
     recommended = recommended_next_action(failure_reasons, dry_run=args.dry_run)
     summary = {
@@ -473,7 +511,7 @@ def main() -> int:
         "backend": "grok-build",
         "grok_bin": args.grok_bin,
         "output_format": args.output_format,
-        "permission_mode": args.permission_mode,
+        "permission_mode": None if args.always_approve else args.permission_mode,
         "no_plan": args.no_plan,
         "verbatim": not args.no_verbatim,
         "session_id": args.session_id,
@@ -484,6 +522,7 @@ def main() -> int:
         "dry_run_payload": dry_run_payload,
         "prompt_bytes": prompt_bytes,
         "exit_code": exit_code,
+        "stop_reason": stop_reason,
         "elapsed_seconds": elapsed,
         "request_bytes": request_bytes,
         "response_bytes": response_bytes,


### PR DESCRIPTION
## 背景

grok-cli-runner のヘッドレス実行が、シェル/ファイル書き込みを伴うタスクで 2 回連続 `stopReason=Cancelled`(exit 0)により成果物を書けず、wrapper は success=true と誤報告していた。原因調査と切り分けの詳細は workspace repo の `.context/grok-cancelled-review/`(01-evidence / 02-spec / 03-isolation / 04-review)を参照。

根本原因:
- ヘッドレス(TTY なし)では permission prompt を誰も承認できず、`--permission-mode auto` 下で最初の `run_terminal_command` が `permission_cancelled` → turn 全体が Cancelled(exit 0)
- grok 0.2.112 では明示 `--permission-mode` が `--always-approve` に勝つ(公式 docs の「always-approve 優先」記載と乖離)ため、両フラグを渡す wrapper 構成では `--always-approve` が無効化されていた
- wrapper が stopReason を検査せず、Cancelled を success=true と報告(静かな失敗)

## 変更内容

- **stopReason ゲート(A-1)**: json / streaming-json stdout から stopReason を抽出し `summary.json.stop_reason` に記録。real run で `EndTurn` 以外なら `stop_reason_not_end_turn` として失敗分類(exit 1、failure.md 生成、recommended_next_action に bypassPermissions での再実行を案内)
- **フラグ相互排他(A-2)**: `--always-approve` 時は `--permission-mode` を grok に送らない(0.2.112 の優先順位問題の回避)。summary の `permission_mode` は実効値(抑止時は null)を記録
- **SKILL.md / schema.md 契約更新(B)**: side-effect タスクは `--permission-mode bypassPermissions` 必須、Success/Failure Criteria に stop_reason 追加、0.2.112 既知問題を Wrapper Notes に記録

## 検証

- `python3 run_grok_cli.py --help` / `py_compile` OK
- no-call: dry-run 成功(stop_reason=null)、invalid request で failure.md + invalid_request 分類
- 実回帰: `--permission-mode auto`(既定)+ mkdir タスク → `success=false`, `stop_reason=Cancelled`, `failure_reasons=[stop_reason_not_end_turn]`, wrapper exit 1
- 実正常: `--always-approve` + mkdir タスク → `stop_reason=EndTurn`, ファイル生成, コマンドに `--permission-mode` 非含有
- `scripts/skill-quick-validate skills/grok-cli-runner` → Skill is valid
- 配備先 `~/.claude/skills/grok-cli-runner` へ同期済み(frontmatter 維持)