### PR TITLE
Improve remote branch review safety

### DIFF
--- a/skills/git-branch-review/SKILL.md
+++ b/skills/git-branch-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-branch-review
-description: Inspect fresh Git branch state across local machines and collaborators. Use when Claude Code or Codex needs to fetch recent remote refs, decide whether a clean local branch can be fast-forwarded from origin, compare local branches with upstream/default branches, check whether branches are merged, or correlate local branches with GitHub PR state.
+description: Inspect fresh local and remote Git branch and GitHub pull request state across machines and collaborators. Use when Claude Code or Codex needs to fetch recent remote refs, detect open PRs without local branches, classify origin branches as deletion candidates, decide whether a clean local branch can be fast-forwarded, compare branches with upstream/default branches, check whether branches are merged, or correlate branches with GitHub PR state.
 ---
 
 # Git Branch Review
@@ -16,7 +16,7 @@ Build a current, conservative view of local and remote Git branch state before d
    - `git status --short --branch`
    - `git remote -v`
    - `git branch --show-current`
-3. Refresh remote knowledge with `git fetch --all --prune` unless the user explicitly asks for offline inspection.
+3. Refresh remote knowledge with `git fetch --all --prune` for a normal or read-only remote review because it does not mutate the server. It may update or remove stale local remote-tracking refs. Use `--no-fetch` only when the user explicitly asks for offline inspection or prohibits local ref updates; do not infer that prohibition from “read-only” alone.
 4. If the user wants the current branch updated from origin, fast-forward only when all conditions are true:
    - worktree is clean by `git status --porcelain`
    - the current branch has an upstream
@@ -24,8 +24,14 @@ Build a current, conservative view of local and remote Git branch state before d
    - remote behind count is greater than `0`
    - `git pull --ff-only` succeeds
 5. Summarize local branches with upstream, ahead/behind counts, merge status relative to `origin/HEAD` or `origin/main`, and latest commit subject.
-6. When GitHub context is available, correlate local branch names with PRs using `gh pr list --state all --head <branch>`. Treat missing `gh` auth or missing PRs as information gaps, not proof that no review happened.
-7. Report recommended next actions separately from facts. Do not delete, rebase, force-push, or merge branches unless the user explicitly asks after seeing the branch review.
+6. When GitHub context is available, list repository-wide open PRs before correlating local and `origin` branch names with same-repository PRs. Do not treat a same-named fork PR as belonging to an `origin` branch.
+7. Classify each `origin` branch conservatively:
+   - `keep`: default branch, protected branch, or branch with an open/draft PR
+   - `safe deletion candidate`: no open/draft PR, not protected, and either merged into the default branch or its current tip matches a merged same-repository PR targeting the default branch
+   - `needs confirmation`: not merged and has no open PR
+   - `unknown`: PR, protection, default-ref, or ancestry information is unavailable
+   Treat age or naming alone as context, never as evidence that deletion is safe.
+8. Report recommended next actions separately from facts. Never delete a local or remote branch unless the user explicitly asks after seeing the review.
 
 ## Script
 
@@ -41,17 +47,19 @@ Useful options:
 
 - `--fast-forward-clean`: update only the current branch, and only when the safety conditions above hold.
 - `--no-fetch`: inspect without refreshing remotes.
-- `--no-pr`: skip `gh pr list` calls.
+- `--no-pr`: skip GitHub PR and protected-branch lookups; remote deletion classification becomes `unknown` except for the default branch.
 
-The script prints progress before network-sensitive work and emits a Markdown report. It uses only `git`, optional `gh`, and the Python standard library.
+The script prints progress before network-sensitive work and emits a Markdown report with facts separated from recommended next actions. It uses only `git`, optional `gh`, and the Python standard library.
 
 ## Output Contract
 
 Include:
 
 - current branch, upstream, worktree cleanliness, ahead/behind counts, and whether a fast-forward ran or was skipped
+- repository-wide open PR table, including PRs whose head branch does not exist locally
+- `origin` remote branch table with deletion classification, reason, protection status, tracking local branches, last update, tip SHA, and subject
 - local branch table with upstream, ahead/behind, merged/not merged relative to default remote ref, PR status, last update, tip SHA, and subject
 - explicit gaps such as `gh unavailable`, fetch failure, no upstream, detached HEAD, or ambiguous default branch
-- concrete next actions, for example `pull --ff-only`, inspect a dirty diff, push an unpublished branch, close a merged PR branch, or ask a collaborator about an unmerged branch
+- a separate recommended-next-actions section; list deletion candidates without executing `git push origin --delete`, surface confirmation and information gaps, and mention a dirty worktree when present
 
-Do not present inferred PR state as certain when `gh` could not query GitHub.
+Do not present inferred PR or deletion safety as certain when `gh` could not query GitHub. In this skill, remote branch deletion means a server-side operation such as `git push origin --delete`; fetch/prune maintenance of local remote-tracking refs is reported separately. Treat the classification as a review result, not authorization to delete.

--- a/skills/git-branch-review/agents/openai.yaml
+++ b/skills/git-branch-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Branch Review"
-  short_description: "Inspect git branches and safe fast-forwards"
-  default_prompt: "Use $git-branch-review to inspect this repository branch state and fast-forward clean branches when safe."
+  short_description: "Review Git branches, remote PRs, and deletion candidates"
+  default_prompt: "Use $git-branch-review to inspect this repository's local and remote branch and pull request state, classify remote deletion candidates, and fast-forward clean branches when safe."

--- a/skills/git-branch-review/scripts/executable_git_branch_review.py
+++ b/skills/git-branch-review/scripts/executable_git_branch_review.py
@@ -82,42 +82,66 @@ def local_branches(cwd: Path) -> list[dict[str, str]]:
     return rows
 
 
-def merged_status(cwd: Path, branch: str, base_ref: str) -> str:
+def remote_branches(cwd: Path) -> list[dict[str, str]]:
+    fmt = "%00".join(
+        [
+            "%(refname:short)",
+            "%(committerdate:iso8601)",
+            "%(objectname)",
+            "%(objectname:short)",
+            "%(subject)",
+        ]
+    )
+    result = git(
+        cwd,
+        "for-each-ref",
+        "refs/remotes/origin",
+        f"--format={fmt}",
+        "--sort=-committerdate",
+        check=True,
+    )
+    rows: list[dict[str, str]] = []
+    for line in result.stdout.splitlines():
+        ref, updated, oid, sha, subject = (line.split("\0") + [""] * 5)[:5]
+        if ref == "origin/HEAD" or not ref.startswith("origin/"):
+            continue
+        rows.append(
+            {
+                "ref": ref,
+                "name": ref.removeprefix("origin/"),
+                "updated": updated,
+                "oid": oid,
+                "sha": sha,
+                "subject": subject,
+            }
+        )
+    return rows
+
+
+def is_ancestor(cwd: Path, branch: str, base_ref: str) -> bool | None:
     if not base_ref:
-        return "unknown"
+        return None
     result = git(cwd, "merge-base", "--is-ancestor", branch, base_ref)
     if result.code == 0:
-        return f"merged into {base_ref}"
+        return True
     if result.code == 1:
+        return False
+    return None
+
+
+def merged_status(cwd: Path, branch: str, base_ref: str) -> str:
+    merged = is_ancestor(cwd, branch, base_ref)
+    if merged is True:
+        return f"merged into {base_ref}"
+    if merged is False:
         return f"not merged into {base_ref}"
     return "unknown"
 
 
-def pr_for_branch(cwd: Path, branch: str) -> str:
-    if shutil.which("gh") is None:
-        return "gh unavailable"
-    result = run(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "all",
-            "--head",
-            branch,
-            "--json",
-            "number,state,mergedAt,isDraft,url,title,baseRefName,updatedAt",
-            "--limit",
-            "5",
-        ],
-        cwd,
-    )
-    if result.code != 0:
-        return "gh error"
-    try:
-        prs = json.loads(result.stdout or "[]")
-    except json.JSONDecodeError:
-        return "gh parse error"
+def pr_for_branch(prs: list[dict[str, object]], branch: str, lookup_status: str) -> str:
+    if lookup_status != "ok":
+        return lookup_status
+    prs = [pr for pr in prs if pr.get("headRefName") == branch]
     if not prs:
         return "no PR found"
     parts: list[str] = []
@@ -128,6 +152,111 @@ def pr_for_branch(cwd: Path, branch: str) -> str:
         draft = " draft" if pr.get("isDraft") else ""
         parts.append(f"#{pr.get('number')} {state}{draft} {pr.get('url')}")
     return "<br>".join(parts)
+
+
+def same_repository_prs(prs: list[dict[str, object]], branch: str) -> list[dict[str, object]]:
+    return [
+        pr
+        for pr in prs
+        if pr.get("headRefName") == branch and pr.get("isCrossRepository") is not True
+    ]
+
+
+def repository_prs(cwd: Path) -> tuple[list[dict[str, object]], str]:
+    if shutil.which("gh") is None:
+        return [], "gh unavailable"
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--json",
+            "number,state,mergedAt,isDraft,url,title,baseRefName,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,updatedAt",
+            "--limit",
+            "1000",
+        ],
+        cwd,
+    )
+    if result.code != 0:
+        return [], "gh error"
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return [], "gh parse error"
+    if not isinstance(prs, list):
+        return [], "gh parse error"
+    return prs, "ok"
+
+
+def protected_branches(cwd: Path) -> tuple[set[str], str]:
+    if shutil.which("gh") is None:
+        return set(), "gh unavailable"
+    result = run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "repos/{owner}/{repo}/branches?protected=true&per_page=100",
+            "--jq",
+            ".[].name",
+        ],
+        cwd,
+    )
+    if result.code != 0:
+        return set(), "gh error"
+    return set(result.stdout.splitlines()), "ok"
+
+
+def remote_branch_classification(
+    cwd: Path,
+    row: dict[str, str],
+    default_remote: str,
+    prs: list[dict[str, object]],
+    pr_lookup_status: str,
+    protected: set[str],
+    protection_status: str,
+) -> tuple[str, str]:
+    if row["ref"] == default_remote:
+        return "keep", "default remote branch"
+    if not default_remote:
+        return "unknown", "ambiguous default remote branch"
+    if pr_lookup_status != "ok" or protection_status != "ok":
+        gaps = sorted(
+            {
+                status
+                for status in (pr_lookup_status, protection_status)
+                if status != "ok"
+            }
+        )
+        return "unknown", ", ".join(gaps)
+    if row["name"] in protected:
+        return "keep", "protected branch"
+
+    branch_prs = same_repository_prs(prs, row["name"])
+    open_prs = [pr for pr in branch_prs if pr.get("state") == "OPEN" and not pr.get("mergedAt")]
+    if open_prs:
+        numbers = ", ".join(f"#{pr.get('number')}" for pr in open_prs)
+        return "keep", f"open or draft PR {numbers}"
+
+    merged = is_ancestor(cwd, row["ref"], default_remote)
+    default_name = default_remote.removeprefix("origin/") if default_remote else ""
+    merged_prs = [
+        pr
+        for pr in branch_prs
+        if pr.get("mergedAt")
+        and pr.get("headRefOid") == row["oid"]
+        and pr.get("baseRefName") == default_name
+    ]
+    if merged is True:
+        return "safe deletion candidate", f"merged into {default_remote}"
+    if merged_prs:
+        numbers = ", ".join(f"#{pr.get('number')}" for pr in merged_prs)
+        return "safe deletion candidate", f"current tip matches merged PR {numbers}"
+    if merged is None:
+        return "unknown", "cannot compare with default remote branch"
+    return "needs confirmation", "not merged and no open PR"
 
 
 def maybe_fast_forward(cwd: Path, branch: str, upstream: str) -> str:
@@ -154,7 +283,11 @@ def main() -> int:
     parser.add_argument("repo", nargs="?", default=".", help="Repository path, default: current directory")
     parser.add_argument("--fast-forward-clean", action="store_true", help="Fast-forward the current branch only when clean and safe")
     parser.add_argument("--no-fetch", action="store_true", help="Skip git fetch --prune")
-    parser.add_argument("--no-pr", action="store_true", help="Skip GitHub PR lookup through gh")
+    parser.add_argument(
+        "--no-pr",
+        action="store_true",
+        help="Skip GitHub PR and protected-branch lookups through gh",
+    )
     args = parser.parse_args()
 
     cwd = Path(args.repo).expanduser().resolve()
@@ -194,16 +327,133 @@ def main() -> int:
     print(f"| default remote ref | {quote_cell(default_remote)} |")
     print(f"| fast-forward | {quote_cell(ff_result)} |")
 
+    branch_rows = local_branches(cwd)
+    remote_branch_rows = remote_branches(cwd)
+    repository_pr_rows: list[dict[str, object]] = []
+    pr_lookup_status = "skipped"
+    protected: set[str] = set()
+    protection_status = "skipped"
+    if not args.no_pr:
+        print("[git-branch-review] querying GitHub PRs")
+        repository_pr_rows, pr_lookup_status = repository_prs(cwd)
+        print("[git-branch-review] querying protected GitHub branches")
+        protected, protection_status = protected_branches(cwd)
+
+    open_pr_rows = [
+        pr for pr in repository_pr_rows if pr.get("state") == "OPEN" and not pr.get("mergedAt")
+    ]
+
+    print("\n## Remote Open PRs\n")
+    if pr_lookup_status != "ok":
+        print(f"GitHub PR lookup: {quote_cell(pr_lookup_status)}")
+    elif not open_pr_rows:
+        print("No open PRs found.")
+    else:
+        local_names = {row["name"] for row in branch_rows}
+        print("| PR | state | head | local branch | base | updated | title |")
+        print("| ---: | --- | --- | --- | --- | --- | --- |")
+        for pr in open_pr_rows:
+            head = str(pr.get("headRefName") or "")
+            state = str(pr.get("state") or "OPEN")
+            if pr.get("isDraft"):
+                state += " draft"
+            number = str(pr.get("number") or "")
+            url = str(pr.get("url") or "")
+            pr_link = f"[#{number}]({url})" if number and url else number or url
+            print(
+                "| "
+                + " | ".join(
+                    quote_cell(value)
+                    for value in [
+                        pr_link,
+                        state,
+                        head,
+                        "yes" if head in local_names else "no",
+                        str(pr.get("baseRefName") or ""),
+                        str(pr.get("updatedAt") or ""),
+                        str(pr.get("title") or ""),
+                    ]
+                )
+                + " |"
+            )
+
+    print("\n## Remote Branches\n")
+    remote_reviews: list[tuple[dict[str, str], str, str]] = []
+    if not remote_branch_rows:
+        print("No origin remote branches found.")
+    else:
+        local_upstreams: dict[str, list[str]] = {}
+        for local in branch_rows:
+            if local["upstream"]:
+                local_upstreams.setdefault(local["upstream"], []).append(local["name"])
+        print("| remote branch | classification | reason | protected | local branches | updated | tip | subject |")
+        print("| --- | --- | --- | --- | --- | --- | --- | --- |")
+        for row in remote_branch_rows:
+            classification, reason = remote_branch_classification(
+                cwd,
+                row,
+                default_remote,
+                repository_pr_rows,
+                pr_lookup_status,
+                protected,
+                protection_status,
+            )
+            remote_reviews.append((row, classification, reason))
+            protected_status = (
+                "unknown" if protection_status != "ok" else "yes" if row["name"] in protected else "no"
+            )
+            print(
+                "| "
+                + " | ".join(
+                    quote_cell(value)
+                    for value in [
+                        row["ref"],
+                        classification,
+                        reason,
+                        protected_status,
+                        ", ".join(local_upstreams.get(row["ref"], [])),
+                        row["updated"],
+                        row["sha"],
+                        row["subject"],
+                    ]
+                )
+                + " |"
+            )
+
+    print("\n## Recommended Next Actions\n")
+    deletion_candidates = [row["name"] for row, status, _ in remote_reviews if status == "safe deletion candidate"]
+    confirmation_needed = [row["name"] for row, status, _ in remote_reviews if status == "needs confirmation"]
+    unknown_branches = [row["name"] for row, status, _ in remote_reviews if status == "unknown"]
+    if deletion_candidates:
+        print(
+            "- Review these remote deletion candidates and obtain explicit approval before running "
+            f"`git push origin --delete`: {', '.join(deletion_candidates)}"
+        )
+    else:
+        print("- No remote branches currently qualify as safe deletion candidates.")
+    if confirmation_needed:
+        print(
+            "- Confirm ownership and intent before deleting unmerged branches: "
+            + ", ".join(confirmation_needed)
+        )
+    if unknown_branches:
+        print(
+            "- Resolve PR, protection, default-ref, or ancestry information gaps before deletion: "
+            + ", ".join(unknown_branches)
+        )
+    if dirty:
+        print("- Inspect the dirty worktree before updating the current branch.")
+
     print("\n## Local Branches\n")
     print("| branch | upstream | ahead | behind | merged | PR | updated | tip | subject |")
     print("| --- | --- | ---: | ---: | --- | --- | --- | --- | --- |")
-    for row in local_branches(cwd):
+    for row in branch_rows:
         upstream_name = row["upstream"]
         counts = ahead_behind(cwd, row["name"], upstream_name) if upstream_name else None
         row_ahead = str(counts[0]) if counts else "-"
         row_behind = str(counts[1]) if counts else "-"
         merged = merged_status(cwd, row["name"], default_remote)
-        pr = "skipped" if args.no_pr else pr_for_branch(cwd, row["name"])
+        pr = pr_for_branch(repository_pr_rows, row["name"], pr_lookup_status)
         print(
             "| "
             + " | ".join(


### PR DESCRIPTION
## Summary

- discover repository-wide open pull requests instead of limiting lookup to local branch names
- classify `origin` branches as keep, safe deletion candidate, needs confirmation, or unknown
- guard deletion candidates with protected-branch, same-repository PR, current-tip, default-branch, and information-completeness checks
- emit recommended next actions without deleting branches

## Why

The previous report was centered on local branches, so pull requests and remote branches without local counterparts were invisible. That made remote cleanup reviews incomplete and required agents to reconstruct safety checks manually.

## Impact

Branch reviews now include remote PRs and origin branches while remaining read-only by default. Deletion still requires explicit approval after the review. Offline or incomplete GitHub information produces conservative `unknown` classifications.

## Validation

- `scripts/skill-quick-validate skills/git-branch-review`
- synthetic fixture validation: 11 checks covering default, protected, open PR, merged ancestry, exact merged-PR tip, fork-name collision, post-merge commits, unmerged branches, and offline behavior
- empirical prompt tuning: two consecutive 100% clear iterations and a 100% unseen hold-out
- live repository smoke test against GitHub PR and branch data
- Codex and Claude Code user-scope installs verified against the publisher source
