### PR TITLE
Add tailscale-app cask for Tailscale remote-access rollout

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -44,6 +44,7 @@ cask "google-chrome"
 cask "maestro"
 cask "ngrok/ngrok/ngrok"
 cask "slack"
+cask "tailscale-app"
 cask "visual-studio-code"
 mas "WireGuard", id: 1451685025
 vscode "antfu.browse-lite"


### PR DESCRIPTION
## 概要

WireGuard から Tailscale への移行 Phase 1 として、`Brewfile` に Tailscale の macOS クライアントを追加する。

## 変更

- `cask "tailscale-app"` を 1 行追加（既存の cask ブロックのアルファベット順を維持）

`mas "WireGuard", id: 1451685025` は意図的に残している。WireGuard の退役は Phase 1 の検証とロールバック期間が完了するまで行わない。

## 選定理由

- `brew info --cask tailscale-app` は公式の Standalone `.pkg`（`pkgs.tailscale.com` 配信、`auto_updates`、macOS >= 12）を指す
- App Store 版・CLI のみの版ではなく Standalone 版を採用する判断は調査時点の handoff に基づく

## chezmoi 上の扱い

- `chezmoi target-path Brewfile` → `~/Brewfile`
- `.chezmoiignore` 4 行目で ignore 済みのため `chezmoi managed` に含まれず、target state は変化しない
- したがって本 PR に `chezmoi apply` は不要

## 検証状況

MBA（この PR の作業機）で実施済み:

- `brew install --cask tailscale-app` 完了、`/Applications/Tailscale.app` 配置を確認
- CLI 統合 `/usr/local/bin/tailscale` を確認
- システム拡張 `io.tailscale.ipn.macsys.network-extension` が `[activated enabled]`
- VPN 構成プロファイルが `Connected`
- tailnet へログイン済み、`BackendState: Running`、MagicDNS 有効

未実施:

- MBP 側のインストール・ログイン（peer 数 0 のため peer 間検証は未着手）
- `tailscale ping` による LAN 直結経路の確認
- 画面共有の有効化と宅内・外部からの接続確認
- MBP のスリープ / 再起動 / FileVault ロック時の到達性
- WireGuard との共存とロールバック確認

## スコープ外

VPS の Exit Node、tailnet 間共有、商用ライセンス可否の判断は本 PR に含まない。
